### PR TITLE
Updated crunchy bridge inventory controller to populate api key from secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@
 - **Next edit the [catalog-source.yaml](config/samples/catalog-source.yaml) template to indicate your new Quay.io org image**  
 - `make release catalog-update`
 - search the Crunchy Bridge Operator in OperatorHub, click on install.
+
+## Enable DBaaS Integration
+
+Follow the steps below to enable integration with DBaaS.
+
+Note: you need  Application ID and Application Secret, for creating a secret. See more, [API Reference](https://docs.crunchybridge.com/api/getting_started)
+
+1. Create a Secret :
+```
+kubectl create secret generic crunchy-bridge-api-key  --from-literal="publicApiKey=<Application ID>"   --from-literal="privateApiSecret=<Application Secret>"   -n crunchy-bridge-operator-system
+```
+2. Create a `CrunchyBridgeInventory` Custom Resource
+```
+kubectl apply -f config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
+```
+
+

--- a/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
@@ -37,9 +37,6 @@ metadata:
             "credentialsRef": {
               "name": "crunchy-bridge-api-key",
               "namespace": "crunchy-bridge-operator-system"
-            },
-            "provider": {
-              "name": "Crunchy Bridge Postgres"
             }
           }
         }

--- a/config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
+++ b/config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
@@ -3,8 +3,6 @@ kind: CrunchyBridgeInventory
 metadata:
   name: crunchybridgeinventory-sample
 spec:
-  provider:
-    name: Crunchy Bridge Postgres
   credentialsRef:
     name: crunchy-bridge-api-key
     namespace: crunchy-bridge-operator-system

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
@@ -18,6 +18,7 @@ package dbaasredhatcom
 
 import (
 	"context"
+	"github.com/CrunchyData/crunchy-bridge-operator/controllers/resources"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -62,8 +63,16 @@ func (r *CrunchyBridgeInventoryReconciler) Reconcile(ctx context.Context, req ct
 		logger.Error(err, "Error fetching CrunchyBridgeInventory for reconcile")
 		return ctrl.Result{}, err
 	}
-	//
 
+	// read the API Key from secret
+	connectionAPIKeys, err := resources.ReadAPIKeysFromSecret(r.Client, ctx, &inventory)
+	if err != nil {
+		// error fetching connectionAPIKeys
+		logger.Error(err, "error fetching matching Secret")
+		return ctrl.Result{}, err
+	}
+	//TODO need to remove from logs once utiliaze the connectionAPIKeys
+	logger.Info("CrunchyBridgeInventory ", "connectionAPIKeys", connectionAPIKeys)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
@@ -18,9 +18,11 @@ package dbaasredhatcom
 
 import (
 	"context"
+	"fmt"
 	"github.com/CrunchyData/crunchy-bridge-operator/controllers/resources"
-
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,8 +73,24 @@ func (r *CrunchyBridgeInventoryReconciler) Reconcile(ctx context.Context, req ct
 		logger.Error(err, "error fetching matching Secret")
 		return ctrl.Result{}, err
 	}
-	//TODO need to remove from logs once utiliaze the connectionAPIKeys
-	logger.Info("CrunchyBridgeInventory ", "connectionAPIKeys", connectionAPIKeys)
+
+	err = r.updateStatus(&inventory, connectionAPIKeys)
+	if err != nil {
+		logger.Error(err, "error fetching instances status")
+		return ctrl.Result{}, err
+	}
+	UpdateCondition(&inventory, "crunchybridgeinventory", metav1.ConditionTrue, "Created")
+	if err = r.Status().Update(ctx, &inventory); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.Info("conflict at status update, requeue to sort it out")
+			return ctrl.Result{}, nil
+		} else {
+			logger.Error(err, "error saving modified CrunchyBridgeInventory status")
+
+			return ctrl.Result{}, err
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -81,4 +99,59 @@ func (r *CrunchyBridgeInventoryReconciler) SetupWithManager(mgr ctrl.Manager) er
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dbaasredhatcomv1alpha1.CrunchyBridgeInventory{}).
 		Complete(r)
+}
+
+func (r *CrunchyBridgeInventoryReconciler) updateStatus(dbaasredhatcomv1alpha1 *dbaasredhatcomv1alpha1.CrunchyBridgeInventory, keys resources.ConnectionAPIKeys) error {
+	var bridgeInstances []dbaasv1alpha1.Instance
+	instance := dbaasv1alpha1.Instance{
+		InstanceID:   "azpiatrcn5eujmhncap73ujeqm",
+		Name:         "example-cluster",
+		InstanceInfo: map[string]string{"provider_id": "aws", "region_id": "us-east-1", "type": "primary"},
+	}
+
+	bridgeInstances = append(bridgeInstances, instance)
+	dbaasredhatcomv1alpha1.Status.Instances = bridgeInstances
+	dbaasredhatcomv1alpha1.Status.Type = "CrunchyBridge Postgres"
+	return nil
+}
+
+// UpdateCondition will update or add the provided condition.
+func UpdateCondition(cr *dbaasredhatcomv1alpha1.CrunchyBridgeInventory, conditionType string, status metav1.ConditionStatus, reason string) {
+
+	message := fmt.Sprintf("%s inventory listed successfully", cr.Name)
+	found := false
+
+	condition := &metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	}
+	conditions := []metav1.Condition{}
+
+	for _, c := range cr.Status.Conditions {
+		if condition.Type != c.Type {
+			conditions = append(conditions, c)
+			continue
+		}
+		if c.Status != condition.Status {
+			c.Status = condition.Status
+			c.LastTransitionTime = condition.LastTransitionTime
+		}
+		if c.Reason != condition.Reason {
+			c.Reason = condition.Reason
+		}
+		if c.Message != condition.Message {
+			c.Message = condition.Message
+		}
+		conditions = append(conditions, c)
+		found = true
+	}
+	cr.Status.Conditions = conditions
+	if !found {
+		conditions = append(conditions, *condition)
+	}
+	cr.Status.Conditions = conditions
+
 }

--- a/controllers/resources/secret.go
+++ b/controllers/resources/secret.go
@@ -1,0 +1,63 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	dbaasredhatcomv1alpha1 "github.com/CrunchyData/crunchy-bridge-operator/apis/dbaas.redhat.com/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	publicAPIKey     = "publicApiKey"
+	privateAPISecret = "privateApiSecret"
+)
+
+// ConnectionAPIKeys encapsulates crunchybridge connectivity information that is necessary to generating token for performing API requests
+type ConnectionAPIKeys struct {
+	PublicKey     string
+	PrivateSecret string
+}
+
+//ReadAPIKeysFromSecret
+func ReadAPIKeysFromSecret(cient client.Client, ctx context.Context, inventory *dbaasredhatcomv1alpha1.CrunchyBridgeInventory) (ConnectionAPIKeys, error) {
+	secret := &corev1.Secret{}
+	selector := client.ObjectKey{
+		Namespace: inventory.Spec.CredentialsRef.Namespace,
+		Name:      inventory.Spec.CredentialsRef.Name,
+	}
+
+	if err := cient.Get(ctx, selector, secret); err != nil {
+		return ConnectionAPIKeys{}, err
+	}
+	secretData := make(map[string]string)
+	for k, v := range secret.Data {
+		secretData[k] = string(v)
+	}
+
+	if err := validateAPIKeysSecret(selector, secretData); err != nil {
+		return ConnectionAPIKeys{}, err
+	}
+
+	return ConnectionAPIKeys{
+		PublicKey:     secretData["publicApiKey"],
+		PrivateSecret: secretData["privateApiSecret"],
+	}, nil
+}
+
+//validateAPIKeysSecret
+func validateAPIKeysSecret(secretRef client.ObjectKey, secretData map[string]string) error {
+	var missingFields []string
+	requiredKeys := []string{publicAPIKey, privateAPISecret}
+
+	for _, key := range requiredKeys {
+		if _, ok := secretData[key]; !ok {
+			missingFields = append(missingFields, key)
+		}
+	}
+
+	if len(missingFields) > 0 {
+		return fmt.Errorf("the following fields are missing in the Secret %v: %v", secretRef, missingFields)
+	}
+	return nil
+}

--- a/controllers/resources/secret_test.go
+++ b/controllers/resources/secret_test.go
@@ -1,0 +1,26 @@
+package resources
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func Test_validateConnectionSecret(t *testing.T) {
+	err := validateAPIKeysSecret(ObjectKey("testNs", "testSecret"), map[string]string{})
+	assert.EqualError(t, err, "the following fields are missing in the Secret testNs/testSecret: [publicApiKey privateApiSecret]")
+
+	err = validateAPIKeysSecret(ObjectKey("testNs", "testSecret"), map[string]string{"publicApiKey": "foo"})
+	assert.EqualError(t, err, "the following fields are missing in the Secret testNs/testSecret: [privateApiSecret]")
+
+	err = validateAPIKeysSecret(ObjectKey("testNs", "testSecret"), map[string]string{"privateApiSecret": "foo"})
+	assert.EqualError(t, err, "the following fields are missing in the Secret testNs/testSecret: [publicApiKey]")
+
+	assert.NoError(t, validateAPIKeysSecret(ObjectKey("testNs", "testSecret"), map[string]string{"publicApiKey": "foo", "privateApiSecret": "foo:wq" +
+		""}))
+
+}
+func ObjectKey(namespace, name string) client.ObjectKey {
+	return types.NamespacedName{Name: name, Namespace: namespace}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/RHEcosystemAppEng/dbaas-operator v1.0.0
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
+	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
The PR opened against issue #4 to read API Application ID/Secret in crunchy bridge inventory controller 

Verify the PR with below steps

1. Run `make install run`

1. Create a Secret :
```
kubectl create secret generic crunchy-bridge-api-key  --from-literal="publicApiKey=<Application ID>"   --from-literal="privateApiSecret=<Application Secret>"   -n crunchy-bridge-operator-system
```
2. Create a `CrunchyBridgeInventory` Custom Resource
```
kubectl apply -f config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
```