### PR TITLE
update DBaaS controller to fetch the inventories

### DIFF
--- a/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinventory_types.go
+++ b/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinventory_types.go
@@ -48,3 +48,9 @@ type CrunchyBridgeInventoryList struct {
 func init() {
 	SchemeBuilder.Register(&CrunchyBridgeInventory{}, &CrunchyBridgeInventoryList{})
 }
+
+// GetStatusConditions gets the status conditions from the
+// ApplicationGroup status
+func (in *CrunchyBridgeInventory) GetStatusConditions() *[]metav1.Condition {
+	return &in.Status.Conditions
+}

--- a/controllers/dbaas.redhat.com/conditions.go
+++ b/controllers/dbaas.redhat.com/conditions.go
@@ -1,0 +1,34 @@
+package dbaasredhatcom
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SpecSynced     string = "SpecSynced"
+	BackendError   string = "BackendError"
+	SyncOK         string = "SyncOK"
+	SuccessMessage string = "Successfully listed crunchy bridge Inventories"
+)
+
+// ObjectWithStatusConditions is an interface that describes kubernetes resource
+// type structs with Status Conditions
+type ObjectWithStatusConditions interface {
+	GetStatusConditions() *[]metav1.Condition
+}
+
+// SetSyncCondition sets the given condition with the given status,
+// reason and message on a resource.
+func setStatusCondition(obj ObjectWithStatusConditions, condition string, status metav1.ConditionStatus, reason, message string) {
+	conditions := obj.GetStatusConditions()
+
+	newCondition := metav1.Condition{
+		Type:    condition,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+
+	apimeta.SetStatusCondition(conditions, newCondition)
+}

--- a/controllers/dbaas.redhat.com/inventory.go
+++ b/controllers/dbaas.redhat.com/inventory.go
@@ -1,0 +1,62 @@
+package dbaasredhatcom
+
+import (
+	dbaasredhatcomv1alpha1 "github.com/CrunchyData/crunchy-bridge-operator/apis/dbaas.redhat.com/v1alpha1"
+	"github.com/CrunchyData/crunchy-bridge-operator/internal/bridgeapi"
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	"strconv"
+)
+
+const (
+	TEAM_ID                = "team_id"
+	PROVIDER_ID            = "provider_id"
+	REGION_ID              = "region_id"
+	CREATED_AT             = "created_at"
+	UPDATED_AT             = "updated_at"
+	MAJOR_VERSION          = "major_version"
+	STORAGE                = "storage"
+	CPU                    = "cpu"
+	MEMORY                 = "memory"
+	IS_HA                  = "is_ha"
+	CRUNCHYBRIDGE_POSTGRES = "Crunchy Bridge managed PostgreSQL"
+)
+
+// discoverInventories query crunchy bridge and return list of inverntories by team
+func (r *CrunchyBridgeInventoryReconciler) discoverInventories(dbaasredhatcomv1alpha1 *dbaasredhatcomv1alpha1.CrunchyBridgeInventory, bridgeapi *bridgeapi.Client, logger logr.Logger) error {
+	var bridgeInstances []dbaasv1alpha1.Instance
+	clusterList, clusterListErr := bridgeapi.ListAllClusters()
+	if clusterListErr != nil {
+		logger.Error(clusterListErr, "Error Listing the instance")
+		return clusterListErr
+	}
+	logger.Info("cluster List ", " Total clusters ", clusterList.Count)
+	if clusterList.Count == 0 {
+		logger.Info("cluster List ", " No Clusters found for account details ", dbaasredhatcomv1alpha1.Spec.CredentialsRef)
+		dbaasredhatcomv1alpha1.Status.Instances = bridgeInstances
+		return nil
+	}
+	for _, cluster := range clusterList.Clusters {
+		clusterSvc := dbaasv1alpha1.Instance{
+			InstanceID: cluster.ID,
+			Name:       cluster.Name,
+			InstanceInfo: map[string]string{
+				TEAM_ID:       cluster.TeamID,
+				PROVIDER_ID:   cluster.ProviderID,
+				REGION_ID:     cluster.RegionID,
+				CREATED_AT:    cluster.Created.String(),
+				UPDATED_AT:    cluster.Updated.String(),
+				MAJOR_VERSION: strconv.Itoa(cluster.PGMajorVersion),
+				STORAGE:       strconv.Itoa(cluster.StorageMB),
+				CPU:           strconv.Itoa(cluster.CPU),
+				MEMORY:        strconv.Itoa(cluster.MemoryGB),
+				IS_HA:         strconv.FormatBool(cluster.HighAvailability),
+			},
+		}
+		bridgeInstances = append(bridgeInstances, clusterSvc)
+	}
+
+	dbaasredhatcomv1alpha1.Status.Instances = bridgeInstances
+	dbaasredhatcomv1alpha1.Status.Type = CRUNCHYBRIDGE_POSTGRES
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.16
 require (
 	github.com/RHEcosystemAppEng/dbaas-operator v1.0.0
 	github.com/go-logr/logr v0.4.0
-	github.com/go-logr/stdr v0.4.0
+	github.com/go-logr/stdr v0.4.0 // indirect
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.5 // indirect
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var crunchybridgeAPIURL string
+	flag.StringVar(&crunchybridgeAPIURL, "crunchybridgeapi-url", "https://api.crunchybridge.com", "the Crunchy bridge API URL (no slash in the end).")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -96,8 +98,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&dbaasredhatcomcontrollers.CrunchyBridgeInventoryReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		APIBaseURL: crunchybridgeAPIURL,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CrunchyBridgeInventory")
 		os.Exit(1)


### PR DESCRIPTION
update the DBaaSInventory controller to set the bridge clusters/inventories, see below status of setting the inventories in requested CR status. 
```
Spec:
  Credentials Ref:
    Name:       crunchy-bridge-api-key
    Namespace:  crunchy-bridge-operator-system
Status:
  Conditions:
    Last Transition Time:  2021-06-16T14:33:20Z
    Message:               Successfully listed crunchy bridge Inventories
    Reason:                SyncOK
    Status:                True
    Type:                  SpecSynced
  Instances:
    Extra Info:
      Cpu:            1
      created_at:     2021-04-01 19:36:19.937782 +0000 UTC
      is_ha:          false
      major_version:  13
      Memory:         2
      provider_id:    aws
      region_id:      us-east-1
      Storage:        100
      team_id:        vp6hlxjcl5g73furjiztcrr2vi
      updated_at:     2021-06-04 21:30:57.53937 +0000 UTC
    Instance ID:      475ow3natngrhaffymv7fbxmha
    Name:             sampledatabasse
    Extra Info:
      Cpu:            1
      created_at:     2021-05-10 13:24:39.504259 +0000 UTC
      is_ha:          true
      major_version:  13
      Memory:         2
      provider_id:    aws
      region_id:      us-east-1
      Storage:        100
      team_id:        vp6hlxjcl5g73furjiztcrr2vi
      updated_at:     2021-06-04 21:30:57.53937 +0000 UTC
    Instance ID:      na7wuu36f5f67oaxm75ngjl5pe
    Name:             test-cluster-ha
  Type:               CrunchyBridge Postgres

```
Signed-off-by: Abdul Hameed <ahameed@redhat.com>