### PR TITLE
Fixed the deployment issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
@@ -86,6 +86,18 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - crunchybridge.crunchydata.com
           resources:
           - bridgeclusters
@@ -250,10 +262,10 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 30Mi
+                    memory: 120Mi
                   requests:
                     cpu: 100m
-                    memory: 20Mi
+                    memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,9 +48,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 120Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - crunchybridge.crunchydata.com
   resources:
   - bridgeclusters

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
@@ -39,6 +39,7 @@ type CrunchyBridgeInventoryReconciler struct {
 }
 
 //+kubebuilder:rbac:groups=dbaas.redhat.com,resources=crunchybridgeinventories,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=dbaas.redhat.com,resources=crunchybridgeinventories/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=dbaas.redhat.com,resources=crunchybridgeinventories/finalizers,verbs=update
 


### PR DESCRIPTION
I ecountered a few issues during deploying the operator using OLM, 

1- The pod was crashing with error status - 'OOMKilled' fixed by increasing the deployment resources limit.

2- error during listing the secret, adding secret resource in rbac.

3- Image was not creating when we running `make release` fixed by adding internal package in docker file copy section











