### PR TITLE
use ConfigMap/Secret for setting connection binding params

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ The CRs status will be updated with connection details of specified instance ID.
 example:
 ```
   connectionInfoRef:
-    name: crunchy-bridge-db-info-b5gs5 // name of configmap contains connection info like host, port, datbase name
+   name: crunchy-bridge-db-conn-cm-k8rkv // name of configmap contains connection info like host, port, datbase name
   credentialsRef:
-    name: crunchy-bridge-db-user-qb9tm // name of secret contains username and password
+   name: crunchy-bridge-db-credentials-vmml2 // name of secret contains username and password
 ```
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,14 @@ Instances:
   ```
   kubectl apply -f config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeconnection.yaml
  ``` 
-The CRs status will be updated with connection details of specified instance ID.
+The CRs status will be updated with connection details of specified instance ID. 
 
 example:
 ```
-connectionInfo:
-instanceId: na7wuu36f5f67oaxm75ngjl5pe
-connectionString: >-postgres://@p<url>:<>/postgres
-credentialsRef:
-name: crunchy-bridge-db-user-s4vgt
+  connectionInfoRef:
+    name: crunchy-bridge-db-info-b5gs5 // name of configmap contains connection info like host, port, datbase name
+  credentialsRef:
+    name: crunchy-bridge-db-user-qb9tm // name of secret contains username and password
 ```
 ## Links
 

--- a/apis/dbaas.redhat.com/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/dbaas.redhat.com/v1alpha1/zz_generated.deepcopy.go
@@ -29,7 +29,7 @@ func (in *CrunchyBridgeConnection) DeepCopyInto(out *CrunchyBridgeConnection) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec.DeepCopyInto(&out.Spec)
+	out.Spec = in.Spec
 	in.Status.DeepCopyInto(&out.Status)
 }
 

--- a/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
@@ -46,7 +46,7 @@ metadata:
           "spec": {
             "credentialsRef": {
               "name": "crunchy-bridge-api-key",
-              "namespace": "crunchy-bridge-operator-system"
+              "namespace": "openshift-dbaas-operator"
             }
           }
         }

--- a/bundle/manifests/dbaas.redhat.com_crunchybridgeconnections.yaml
+++ b/bundle/manifests/dbaas.redhat.com_crunchybridgeconnections.yaml
@@ -39,17 +39,19 @@ spec:
                 description: The ID of the instance to connect to, as seen in the
                   Status of the referenced DBaaSInventory
                 type: string
-              inventory:
+              inventoryRef:
                 description: A reference to the relevant DBaaSInventory CR
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: The name for object of known type
+                    type: string
+                  namespace:
+                    description: The namespace where object of known type is store
                     type: string
                 type: object
             required:
             - instanceID
-            - inventory
+            - inventoryRef
             type: object
           status:
             description: DBaaSConnectionStatus defines the observed state of DBaaSConnection
@@ -123,17 +125,18 @@ spec:
                   - type
                   type: object
                 type: array
-              connectionInfo:
-                additionalProperties:
-                  type: string
-                description: Any other provider-specific information related to this
-                  connection
+              connectionInfoRef:
+                description: ConfigMap holding non-sensitive information needed for
+                  connecting to the DB instance
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
                 type: object
-              connectionString:
-                description: The connection string for this instance
-                type: string
               credentialsRef:
-                description: Secret holding username and password
+                description: Secret holding credentials needed for accessing the DB
+                  instance
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/bundle/manifests/dbaas.redhat.com_crunchybridgeinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_crunchybridgeinventories.yaml
@@ -126,15 +126,15 @@ spec:
                 description: A list of instances returned from querying the DB provider
                 items:
                   properties:
-                    extraInfo:
+                    instanceID:
+                      description: The ID for this instance in the database service
+                      type: string
+                    instanceInfo:
                       additionalProperties:
                         type: string
                       description: Any other provider-specific information related
                         to this instance
                       type: object
-                    instanceID:
-                      description: The ID for this instance in the database service
-                      type: string
                     name:
                       description: The name of this instance in the database service
                       type: string
@@ -142,11 +142,6 @@ spec:
                   - instanceID
                   type: object
                 type: array
-              type:
-                description: E.g., MongoDB, Postgres
-                type: string
-            required:
-            - type
             type: object
         type: object
     served: true

--- a/config/crd/bases/dbaas.redhat.com_crunchybridgeconnections.yaml
+++ b/config/crd/bases/dbaas.redhat.com_crunchybridgeconnections.yaml
@@ -41,17 +41,19 @@ spec:
                 description: The ID of the instance to connect to, as seen in the
                   Status of the referenced DBaaSInventory
                 type: string
-              inventory:
+              inventoryRef:
                 description: A reference to the relevant DBaaSInventory CR
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: The name for object of known type
+                    type: string
+                  namespace:
+                    description: The namespace where object of known type is store
                     type: string
                 type: object
             required:
             - instanceID
-            - inventory
+            - inventoryRef
             type: object
           status:
             description: DBaaSConnectionStatus defines the observed state of DBaaSConnection
@@ -125,17 +127,18 @@ spec:
                   - type
                   type: object
                 type: array
-              connectionInfo:
-                additionalProperties:
-                  type: string
-                description: Any other provider-specific information related to this
-                  connection
+              connectionInfoRef:
+                description: ConfigMap holding non-sensitive information needed for
+                  connecting to the DB instance
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
                 type: object
-              connectionString:
-                description: The connection string for this instance
-                type: string
               credentialsRef:
-                description: Secret holding username and password
+                description: Secret holding credentials needed for accessing the DB
+                  instance
                 properties:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/config/crd/bases/dbaas.redhat.com_crunchybridgeinventories.yaml
+++ b/config/crd/bases/dbaas.redhat.com_crunchybridgeinventories.yaml
@@ -128,15 +128,15 @@ spec:
                 description: A list of instances returned from querying the DB provider
                 items:
                   properties:
-                    extraInfo:
+                    instanceID:
+                      description: The ID for this instance in the database service
+                      type: string
+                    instanceInfo:
                       additionalProperties:
                         type: string
                       description: Any other provider-specific information related
                         to this instance
                       type: object
-                    instanceID:
-                      description: The ID for this instance in the database service
-                      type: string
                     name:
                       description: The name of this instance in the database service
                       type: string
@@ -144,11 +144,6 @@ spec:
                   - instanceID
                   type: object
                 type: array
-              type:
-                description: E.g., MongoDB, Postgres
-                type: string
-            required:
-            - type
             type: object
         type: object
     served: true

--- a/config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
+++ b/config/samples/dbaas.redhat.com_v1alpha1_crunchybridgeinventory.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   credentialsRef:
     name: crunchy-bridge-api-key
-    namespace: crunchy-bridge-operator-system
+    namespace: openshift-dbaas-operator

--- a/controllers/dbaas.redhat.com/conditions.go
+++ b/controllers/dbaas.redhat.com/conditions.go
@@ -7,13 +7,15 @@ import (
 )
 
 const (
-	SpecSynced        string = "SpecSynced"
-	BackendError      string = "BackendError"
-	SyncOK            string = "SyncOK"
-	ReadyForBinding   string = "ReadyForBinding"
-	NotFound          string = "NotFound"
-	SuccessMessage    string = "Successfully listed crunchy bridge Inventories"
-	SuccessConnection string = "Successfully retrieved the connection detail\n"
+	SpecSynced          string = "SpecSynced"
+	BackendError        string = "BackendError"
+	AuthenticationError string = "AuthenticationError"
+	SyncOK              string = "SyncOK"
+	ReadyForBinding     string = "ReadyForBinding"
+	Ready               string = "Ready"
+	NotFound            string = "NotFound"
+	SuccessMessage      string = "Successfully listed crunchy bridge Inventories"
+	SuccessConnection   string = "Successfully retrieved the connection detail\n"
 )
 
 // ObjectWithStatusConditions is an interface that describes kubernetes resource

--- a/controllers/dbaas.redhat.com/configmap.go
+++ b/controllers/dbaas.redhat.com/configmap.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	PROVIDERDATAVALUE = "Crunchy Bridge managed PostgreSQL"
-	PROVIDERDATAKEY   = "provider"
-
+	PROVIDERDATAVALUE     = "Red Hat DBaaS / Crunchy Bridge"
+	PROVIDERDATAKEY       = "provider"
+	DISPLAYNAMEKEY        = "display_name"
+	DISPLAYNAMEVALUE      = "Crunchy Bridge managed PostgreSQL"
 	INVENTORYDATAVALUE    = "CrunchyBridgeInventory"
 	INVENTORYKINDDATAKEY  = "inventory_kind"
 	CONNECTIONKINDDATAKEY = "connection_kind"
@@ -37,7 +38,7 @@ const (
 	CREDENTIALFIELDS      = "credentials_fields"
 	LOGO                  = "logo"
 	NAME                  = "crunchy-bridge-registration"
-	NAMESPACE             = "dbaas-operator" //configmap namespace
+	NAMESPACE             = "openshift-dbaas-operator" //configmap namespace
 	RELATEDTOLABELNAME    = "related-to"
 	RELATEDTOLABELVALUE   = "dbaas-operator"
 	TYPELABELNAME         = "type"
@@ -87,6 +88,7 @@ func CreateBridgeRegistrationConfigMap(mgr manager.Manager) error {
 			},
 			Data: map[string]string{
 				PROVIDERDATAKEY:       PROVIDERDATAVALUE,
+				DISPLAYNAMEKEY:        DISPLAYNAMEVALUE,
 				INVENTORYKINDDATAKEY:  INVENTORYDATAVALUE,
 				CONNECTIONKINDDATAKEY: CONNECTIONDATAVALUE,
 				LOGO:                  logoValues,

--- a/controllers/dbaas.redhat.com/crunchybridgeconnection_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeconnection_controller.go
@@ -69,7 +69,7 @@ func (r *CrunchyBridgeConnectionReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 	inventory := dbaasredhatcomv1alpha1.CrunchyBridgeInventory{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: connection.Spec.InventoryRef.Name}, &inventory); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: connection.Spec.InventoryRef.Namespace, Name: connection.Spec.InventoryRef.Name}, &inventory); err != nil {
 		if apierrors.IsNotFound(err) {
 			// CR deleted since request queued, child objects getting GC'd, no requeue
 			logger.Info("inventory resource not found, has been deleted")

--- a/controllers/dbaas.redhat.com/crunchybridgeconnection_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeconnection_controller.go
@@ -110,7 +110,7 @@ func (r *CrunchyBridgeConnectionReconciler) Reconcile(ctx context.Context, req c
 		logger.Error(err, "Error while getting connection details")
 		return ctrl.Result{}, err
 	}
-	statusErr := r.updateStatus(ctx, connection, metav1.ConditionTrue, ReadyForBinding, SuccessConnection)
+	statusErr := r.updateStatus(ctx, connection, metav1.ConditionTrue, Ready, SuccessConnection)
 	if statusErr != nil {
 		logger.Error(statusErr, "Error in updating CrunchyBridgeInventory status")
 		return ctrl.Result{Requeue: true}, statusErr

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller.go
@@ -69,7 +69,7 @@ func (r *CrunchyBridgeInventoryReconciler) Reconcile(ctx context.Context, req ct
 
 	bridgeapiClient, err := setupClient(r.Client, inventory, r.APIBaseURL, logger)
 	if err != nil {
-		statusErr := r.updateStatus(ctx, inventory, metav1.ConditionFalse, BackendError, err.Error())
+		statusErr := r.updateStatus(ctx, inventory, metav1.ConditionFalse, AuthenticationError, err.Error())
 		if statusErr != nil {
 			logger.Error(statusErr, "Error in updating CrunchyBridgeInventory status")
 			return ctrl.Result{Requeue: true}, statusErr

--- a/controllers/dbaas.redhat.com/inventory.go
+++ b/controllers/dbaas.redhat.com/inventory.go
@@ -9,17 +9,16 @@ import (
 )
 
 const (
-	TEAM_ID                = "team_id"
-	PROVIDER_ID            = "provider_id"
-	REGION_ID              = "region_id"
-	CREATED_AT             = "created_at"
-	UPDATED_AT             = "updated_at"
-	MAJOR_VERSION          = "major_version"
-	STORAGE                = "storage"
-	CPU                    = "cpu"
-	MEMORY                 = "memory"
-	IS_HA                  = "is_ha"
-	CRUNCHYBRIDGE_POSTGRES = "Crunchy Bridge managed PostgreSQL"
+	TEAM_ID       = "team_id"
+	PROVIDER_ID   = "provider_id"
+	REGION_ID     = "region_id"
+	CREATED_AT    = "created_at"
+	UPDATED_AT    = "updated_at"
+	MAJOR_VERSION = "major_version"
+	STORAGE       = "storage"
+	CPU           = "cpu"
+	MEMORY        = "memory"
+	IS_HA         = "is_ha"
 )
 
 // discoverInventories query crunchy bridge and return list of inverntories by team
@@ -57,6 +56,6 @@ func (r *CrunchyBridgeInventoryReconciler) discoverInventories(dbaasredhatcomv1a
 	}
 
 	dbaasredhatcomv1alpha1.Status.Instances = bridgeInstances
-	dbaasredhatcomv1alpha1.Status.Type = CRUNCHYBRIDGE_POSTGRES
+
 	return nil
 }


### PR DESCRIPTION
Updated Operator to use ConfigMap/Secret for all connection params based on the latest API design from DBaas Operator

<img width="529" alt="Screen Shot 2021-07-09 at 5 04 29 PM" src="https://user-images.githubusercontent.com/41960152/125140318-d4efae00-e0d7-11eb-86c0-d674e04e059c.png">


The confimap data contains- host, port, database and type
<img width="768" alt="Screen Shot 2021-07-09 at 4 09 44 PM" src="https://user-images.githubusercontent.com/41960152/125137031-7e7f7100-e0d1-11eb-9bd0-28caf9dd8498.png">




Signed-off-by: Abdul <ahameed@redhat.com>