### PR TITLE
added units and integration tests for  inventory, connection & provider controllers

### DIFF
--- a/config/test/crd/dbaas.redhat.com_dbaasproviders.yaml
+++ b/config/test/crd/dbaas.redhat.com_dbaasproviders.yaml
@@ -1,0 +1,125 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: dbaasproviders.dbaas.redhat.com
+spec:
+  group: dbaas.redhat.com
+  names:
+    kind: DBaaSProvider
+    listKind: DBaaSProviderList
+    plural: dbaasproviders
+    singular: dbaasprovider
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DBaaSProvider is the Schema for the dbaasproviders API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DBaaSProviderSpec defines the desired state of DBaaSProvider
+            properties:
+              connectionKind:
+                description: ConnectionKind is the name of the connection resource
+                  (CRD) defined by the provider
+                type: string
+              credentialFields:
+                description: CredentialFields indicates what information to collect
+                  from UX & how to display fields in a form
+                items:
+                  properties:
+                    displayName:
+                      description: A user-friendly name for this field
+                      type: string
+                    key:
+                      description: The name for this field
+                      type: string
+                    required:
+                      description: If this field is required or not
+                      type: boolean
+                    type:
+                      description: The type of field (string, maskedstring, integer,
+                        boolean)
+                      type: string
+                  required:
+                  - displayName
+                  - key
+                  - required
+                  - type
+                  type: object
+                type: array
+              inventoryKind:
+                description: InventoryKind is the name of the inventory resource (CRD)
+                  defined by the provider
+                type: string
+              provider:
+                description: Provider contains information about database provider
+                  & platform
+                properties:
+                  displayDescription:
+                    description: DisplayDescription indicates the description text
+                      shown for a Provider within UX (e.g. developer’s catalog tile)
+                    type: string
+                  displayName:
+                    description: A user-friendly name for this database provider (e.g.
+                      'MongoDB Atlas')
+                    type: string
+                  icon:
+                    description: Icon information indicates what logo we display on
+                      developer catalog tile
+                    properties:
+                      base64data:
+                        type: string
+                      mediatype:
+                        type: string
+                    required:
+                    - base64data
+                    - mediatype
+                    type: object
+                  name:
+                    description: Indicates the name used to specify Service Binding
+                      origin parameter (e.g. 'Red Hat DBaas / MongoDB Atlas')
+                    type: string
+                required:
+                - displayDescription
+                - displayName
+                - icon
+                - name
+                type: object
+            required:
+            - connectionKind
+            - credentialFields
+            - inventoryKind
+            - provider
+            type: object
+          status:
+            description: DBaaSProviderStatus defines the observed state of DBaaSProvider
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/controllers/dbaas.redhat.com/common_test.go
+++ b/controllers/dbaas.redhat.com/common_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dbaasredhatcom
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EventuallyExists checks if an object with the given namespace+name and type eventually exists.
+func EventuallyExists(obj client.Object) {
+	Eventually(func() bool {
+
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if errors.IsNotFound(err) {
+			return false
+		}
+		Expect(err).NotTo(HaveOccurred())
+		return true
+	}).Should(BeTrue())
+}
+
+// CRDEventuallyExists checks if a custom resource definition with the given name eventually exists.
+func CRDEventuallyExists(crdName string) {
+	crd := &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+	}
+	EventuallyExists(crd)
+}
+
+// assertResourceCreation create the resources
+func assertResourceCreation(object client.Object) func() {
+	return func() {
+		By("creating resource")
+		object.SetResourceVersion("")
+		Expect(k8sClient.Create(ctx, object)).Should(Succeed())
+
+		By("checking the resource created")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object)
+			if err != nil {
+				return false
+			}
+			return true
+		}, timeout, interval).Should(BeTrue())
+	}
+}
+
+// assertResourceDeletion resource deletion
+func assertResourceDeletion(object client.Object) func() {
+	return func() {
+		By("deleting resource")
+		Expect(k8sClient.Delete(ctx, object)).Should(Succeed())
+
+		By("checking the resource deleted")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(object), object)
+			if err != nil && errors.IsNotFound(err) {
+				return true
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
+	}
+}

--- a/controllers/dbaas.redhat.com/conditions.go
+++ b/controllers/dbaas.redhat.com/conditions.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package dbaasredhatcom
 
 import (

--- a/controllers/dbaas.redhat.com/connection.go
+++ b/controllers/dbaas.redhat.com/connection.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package dbaasredhatcom
 
 import (

--- a/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
@@ -37,7 +37,6 @@ const (
 var _ = Describe("CrunchyBridgeConnection controller", func() {
 
 	Describe("CrunchyBridgeConnectionReconciler", func() {
-		BeforeEach(func() {})
 		AfterEach(assertResourceDeletion(connectionCR()))
 
 		Context("CrunchyBridgeConnection", func() {

--- a/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dbaasredhatcom
 
 import (

--- a/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeconnection_controller_test.go
@@ -1,0 +1,72 @@
+package dbaasredhatcom
+
+import (
+	"github.com/CrunchyData/crunchy-bridge-operator/apis/dbaas.redhat.com/v1alpha1"
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	timeout          = time.Second * 10
+	duration         = time.Second * 10
+	interval         = time.Millisecond * 250
+	inventoryRefName = "test-inventory-ref"
+)
+
+var _ = Describe("CrunchyBridgeConnection controller", func() {
+
+	Describe("CrunchyBridgeConnectionReconciler", func() {
+		BeforeEach(func() {})
+		AfterEach(assertResourceDeletion(connectionCR()))
+
+		Context("CrunchyBridgeConnection", func() {
+			It("Should create connection instance successfully", func() {
+
+				By("By creating inventory instance")
+
+				inventory := createInventories(inventoryRefName)
+				EventuallyExists(inventory)
+
+				By("By creating connection instance")
+				connection := connectionCR()
+				Expect(k8sClient.Create(ctx, connection)).Should(Succeed())
+
+				By("getting connection instance")
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(connection), connection)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("getting a inventory instance")
+				err = k8sClient.Get(ctx, types.NamespacedName{Namespace: connection.Spec.InventoryRef.Namespace, Name: connection.Spec.InventoryRef.Name}, inventory)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+
+		})
+	})
+})
+
+func connectionCR() *v1alpha1.CrunchyBridgeConnection {
+	connectionName := "test-connection"
+	instanceID := "testInstanceID"
+	DBaaSConnectionSpec := &dbaasv1alpha1.DBaaSConnectionSpec{
+		InventoryRef: dbaasv1alpha1.NamespacedName{
+			Name:      inventoryRefName,
+			Namespace: testNamespace,
+		},
+		InstanceID: instanceID,
+	}
+	connection := &v1alpha1.CrunchyBridgeConnection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      connectionName,
+			Namespace: testNamespace,
+		},
+		Spec: *DBaaSConnectionSpec,
+	}
+
+	return connection
+}

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
@@ -1,0 +1,118 @@
+package dbaasredhatcom
+
+import (
+	"github.com/CrunchyData/crunchy-bridge-operator/apis/dbaas.redhat.com/v1alpha1"
+	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	credentialsRefName = "test-credentials-ref"
+	inventoryName      = "test-inventory"
+	privateApiSecret   = "test"
+	publicApiKey       = "test"
+)
+
+var _ = Describe("CrunchyBridgeInventory controller", func() {
+
+	BeforeEach(func() {})
+	AfterEach(func() {})
+	Context("CrunchyBridgeInventories", func() {
+		It("Should create, update and delete inventory cr successfully", func() {
+
+			By("creating inventory and updating status")
+			inventory := createInventories(inventoryName)
+
+			cond := GetInventoryCondition(inventory, string(SpecSynced))
+			Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+
+			By("deleting inventory")
+			Expect(k8sClient.Delete(ctx, inventory)).Should(Succeed())
+
+			By("checking the inventory deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(inventory), inventory)
+				if err != nil && errors.IsNotFound(err) {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+})
+
+func updateMockStatus(inventory *v1alpha1.CrunchyBridgeInventory) {
+	By("setting up status")
+	lastTransitionTime, err := time.Parse(time.RFC3339, "2021-06-30T22:17:55-04:00")
+	Expect(err).NotTo(HaveOccurred())
+
+	lastTransitionTime = lastTransitionTime.In(time.Local)
+	status := &dbaasv1alpha1.DBaaSInventoryStatus{
+		Instances: []dbaasv1alpha1.Instance{
+			{
+				InstanceID: "testInstanceID",
+				Name:       "testInstance",
+				InstanceInfo: map[string]string{
+					"testInstanceInfo": "testInstanceInfo",
+				},
+			},
+		},
+		Conditions: []metav1.Condition{
+			{
+				Type:               "SpecSynced",
+				Status:             metav1.ConditionTrue,
+				Reason:             "SyncOK",
+				LastTransitionTime: metav1.Time{Time: lastTransitionTime},
+			},
+		},
+	}
+	inventory.Status = *status
+	Expect(k8sClient.Status().Update(ctx, inventory)).Should(Succeed())
+
+}
+
+func createInventories(inventoryName string) *v1alpha1.CrunchyBridgeInventory {
+	credentialSecret := createSecret(testNamespace)
+
+	DBaaSInventorySpec := &dbaasv1alpha1.DBaaSInventorySpec{
+		CredentialsRef: &dbaasv1alpha1.NamespacedName{
+			Name:      credentialSecret.Name,
+			Namespace: testNamespace,
+		},
+	}
+	inventory := &v1alpha1.CrunchyBridgeInventory{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inventoryName,
+			Namespace: testNamespace,
+		},
+		Spec: *DBaaSInventorySpec,
+	}
+	By("creating a inventory instance")
+	Expect(k8sClient.Create(ctx, inventory)).To(Succeed())
+
+	updateMockStatus(inventory)
+
+	return inventory
+}
+
+func createSecret(namespace string) *corev1.Secret {
+	credentialSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: credentialsRefName + "-",
+			Namespace:    namespace,
+		},
+		Data: map[string][]byte{
+			KEYFIELDNAME:    []byte(publicApiKey),
+			SECRETFIELDNAME: []byte(privateApiSecret),
+		},
+	}
+	Expect(k8sClient.Create(ctx, credentialSecret)).To(Succeed())
+	return credentialSecret
+}

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dbaasredhatcom
 
 import (

--- a/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinventory_controller_test.go
@@ -37,8 +37,6 @@ const (
 
 var _ = Describe("CrunchyBridgeInventory controller", func() {
 
-	BeforeEach(func() {})
-	AfterEach(func() {})
 	Context("CrunchyBridgeInventories", func() {
 		It("Should create, update and delete inventory cr successfully", func() {
 

--- a/controllers/dbaas.redhat.com/dbaasprovider_reconciler_test.go
+++ b/controllers/dbaas.redhat.com/dbaasprovider_reconciler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dbaasredhatcom
 
 import (

--- a/controllers/dbaas.redhat.com/dbaasprovider_reconciler_test.go
+++ b/controllers/dbaas.redhat.com/dbaasprovider_reconciler_test.go
@@ -1,0 +1,54 @@
+package dbaasredhatcom
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const commonName = "test-provider"
+
+var _ = Describe("DBaaS Provider Controller", func() {
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: commonName + "-cluster-role"},
+		Rules:      []rbacv1.PolicyRule{{Verbs: []string{"create"}, APIGroups: []string{"dbaas.redhat.com"}, Resources: []string{"*"}}},
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: commonName + "-"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: commonName + "-cluster-role"},
+		Subjects:   []rbacv1.Subject{{APIGroup: "rbac.authorization.k8s.io", Kind: "User", Name: commonName}},
+	}
+
+	BeforeEach(assertResourceCreation(clusterRole))
+	BeforeEach(assertResourceCreation(clusterRoleBinding))
+	AfterEach(assertResourceDeletion(clusterRole))
+	AfterEach(assertResourceDeletion(clusterRoleBinding))
+
+	Context(" provider creation", func() {
+		It("Should create provider cr successfully", func() {
+
+			dep := &v1.Deployment{}
+
+			assertResourceCreation(dep)
+
+			clusterRoleList := &rbacv1.ClusterRoleList{}
+			err := k8sClient.List(context.Background(), clusterRoleList)
+
+			Expect(err).NotTo(HaveOccurred())
+			// check CRD exists
+			CRDEventuallyExists("dbaasproviders.dbaas.redhat.com")
+
+			By("creating a instance")
+			providerCR := bridgeProviderCR(clusterRoleList)
+			assertResourceCreation(providerCR)
+			assertResourceDeletion(providerCR)
+
+		})
+	})
+
+})


### PR DESCRIPTION

added DBaaS controllers tests- see more details for the approached use here https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html

validate using the command `make test`
```
?       github.com/CrunchyData/crunchy-bridge-operator  [no test files]
?       github.com/CrunchyData/crunchy-bridge-operator/apis/crunchybridge/v1alpha1      [no test files]
?       github.com/CrunchyData/crunchy-bridge-operator/apis/dbaas.redhat.com/v1alpha1   [no test files]
ok      github.com/CrunchyData/crunchy-bridge-operator/controllers/crunchybridge        7.531s  coverage: 0.0% of statements
ok      github.com/CrunchyData/crunchy-bridge-operator/controllers/dbaas.redhat.com     8.236s  coverage: 36.0% of statements
?       github.com/CrunchyData/crunchy-bridge-operator/internal/bridgeapi       [no test files]
?       github.com/CrunchyData/crunchy-bridge-operator/internal/kubeadapter     [no test files]

```


Signed-off-by: Abdul Hameed <ahameed@redhat.com>