### PR TITLE
sets up bridge controller for upcoming API changes

### DIFF
--- a/controllers/dbaas.redhat.com/inventory.go
+++ b/controllers/dbaas.redhat.com/inventory.go
@@ -29,8 +29,8 @@ func (r *CrunchyBridgeInventoryReconciler) discoverInventories(dbaasredhatcomv1a
 		logger.Error(clusterListErr, "Error Listing the instance")
 		return clusterListErr
 	}
-	logger.Info("cluster List ", " Total clusters ", clusterList.Count)
-	if clusterList.Count == 0 {
+	logger.Info("cluster List ", " Total clusters ", len(clusterList.Clusters))
+	if len(clusterList.Clusters) == 0 {
 		logger.Info("cluster List ", " No Clusters found for account details ", dbaasredhatcomv1alpha1.Spec.CredentialsRef)
 		dbaasredhatcomv1alpha1.Status.Instances = bridgeInstances
 		return nil

--- a/internal/bridgeapi/client.go
+++ b/internal/bridgeapi/client.go
@@ -284,7 +284,6 @@ func (c *Client) ListAllClusters() (ClusterList, error) {
 			return ClusterList{}, err
 		}
 		allClusters.Clusters = append(allClusters.Clusters, toAdd.Clusters...)
-		allClusters.Count += toAdd.Count
 	}
 	// At the time of this code, the team order is sorted by personal, then
 	// other teams and by team name
@@ -361,15 +360,23 @@ func (c *Client) ClusterDetail(id string) (ClusterDetail, error) {
 		return ClusterDetail{}, errors.New("unexpected response status from API")
 	}
 
+	// transition type handles both pre-denested and nested unmarshal, leaving
+	// to remaining logic
 	var detail struct {
-		Cluster ClusterDetail
+		ClusterDetail               // handle newer style
+		Cluster       ClusterDetail // handler older style
 	}
 	err = json.NewDecoder(resp.Body).Decode(&detail)
 	if err != nil {
 		c.log.Error(err, "error unmarshaling response body (cluster detail)")
 		return ClusterDetail{}, err
 	}
-	return detail.Cluster, nil
+
+	if detail.ClusterDetail.ID != "" {
+		return detail.ClusterDetail, nil
+	} else {
+		return detail.Cluster, nil
+	}
 }
 
 func (c *Client) DeleteCluster(id string) error {

--- a/internal/bridgeapi/types.go
+++ b/internal/bridgeapi/types.go
@@ -90,7 +90,6 @@ type CreateRequest struct {
 
 type ClusterList struct {
 	Clusters []ClusterDetail `json:"clusters"`
-	Count    int             `json:"total_count"`
 }
 
 type ClusterDetail struct {


### PR DESCRIPTION
* Handles both packed and unpacked cluster detail
* Removes any processing of total_count, used for paging