### PR TITLE
adds support for default trial provisioning

### DIFF
--- a/controllers/dbaas.redhat.com/crunchybridgeinstance_controller.go
+++ b/controllers/dbaas.redhat.com/crunchybridgeinstance_controller.go
@@ -230,8 +230,8 @@ func (r *CrunchyBridgeInstanceReconciler) createFromSpec(spec dbaasv1alpha1.DBaa
 		Name:           spec.Name,
 		PGMajorVersion: 13,
 		Plan:           "trial",
-		Provider:       "aws",
-		Region:         "us-east-1",
+		Provider:       spec.CloudProvider,
+		Region:         spec.CloudRegion,
 	}
 
 	if teamID, ok := spec.OtherInstanceParams["TeamID"]; ok {
@@ -264,15 +264,16 @@ func (r *CrunchyBridgeInstanceReconciler) createFromSpec(spec dbaasv1alpha1.DBaa
 	// trial configuration
 	if req.Plan == "trial" {
 		req.StorageGB = 10
-		if spec.CloudRegion == "aws" {
-			// Allow requesting region if requesting on AWS, where trials
-			// are allowed
-			req.Region = spec.CloudRegion
-		}
 		req.HighAvailability = false
-	} else {
-		req.Provider = spec.CloudProvider
-		req.Region = spec.CloudRegion
+		req.Plan = "hobby-2"
+		req.Trial = true
+
+		// Allow requesting region if requesting on AWS, where trials
+		// are allowed, otherwise overwrite requested to trial-allowed
+		if spec.CloudProvider != "aws" {
+			req.Provider = "aws"
+			req.Region = "us-east-1"
+		}
 	}
 
 	return req, nil

--- a/controllers/dbaas.redhat.com/dbaasprovider_reconciler.go
+++ b/controllers/dbaas.redhat.com/dbaasprovider_reconciler.go
@@ -62,7 +62,7 @@ const (
 	TYPELABELVALUE         = "dbaas-provider-registration"
 	DBAASPROVIDERKIND      = "DBaaSProvider"
 	PROVISION_DOC_URL      = "https://docs.crunchybridge.com/quickstart/provision"
-	PROVISION_DESCRIPTION  = "At this time, Crunchy Bridge by Crunchy Data is not offering free trial instances. For further information on provisioning paid instances via the Crunchy Bridge platform, please refer to our provisioning documentation."
+	PROVISION_DESCRIPTION  = "Crunchy Bridge by Crunchy Data offers free trial instances through RHODA. To provision a trial instance, provision through RHODA using default parameters or specify the plan as 'trial'. For further information on provisioning paid instances via the Crunchy Bridge platform, please refer to our provisioning documentation."
 )
 
 var labels = map[string]string{RELATEDTOLABELNAME: RELATEDTOLABELVALUE, TYPELABELNAME: TYPELABELVALUE}
@@ -204,7 +204,7 @@ func bridgeProviderCR(clusterRoleList *rbac.ClusterRoleList) *dbaasoperator.DBaa
 					Required:    true,
 				},
 			},
-			AllowsFreeTrial:              false,
+			AllowsFreeTrial:              true,
 			ExternalProvisionURL:         PROVISION_DOC_URL,
 			ExternalProvisionDescription: PROVISION_DESCRIPTION,
 			InstanceParameterSpecs: []dbaasoperator.InstanceParameterSpec{

--- a/internal/bridgeapi/types.go
+++ b/internal/bridgeapi/types.go
@@ -86,6 +86,7 @@ type CreateRequest struct {
 	Region           string `json:"region_id"`
 	PGMajorVersion   int    `json:"major_version"`
 	HighAvailability bool   `json:"is_ha"`
+	Trial            bool   `json:"is_trial"`
 }
 
 type ClusterList struct {


### PR DESCRIPTION
Treats default plan as trial plan while allowing provisioning
requests for alternate plans for those with payment methods
on file.

This change requires trial plan support in the Crunchy Bridge API
otherwise the "trial" plan type will be unknown and rejected.