### PR TITLE
retrieves Create error detail and percolates

### DIFF
--- a/internal/bridgeapi/types.go
+++ b/internal/bridgeapi/types.go
@@ -122,3 +122,8 @@ type tokenResponse struct {
 	Token     string `json:"access_token"`
 	TokenID   string `json:"id"`
 }
+
+type APIMessage struct {
+	Message   string `json:"message"`
+	RequestID string `json:"request_id"`
+}


### PR DESCRIPTION
The Crunchy Bridge API has additional error message clarify beyond the
HTTP status-code based responses that existed when this library was
written. This change extends the error returned to continue to work with
an error type check using Go's .Is() facility, but includes the
additional error detail in the message for basic error processing and
dumps the request ID into the logs for correlation to Crunchy Bridge
logging systems, if available.