### PR TITLE
use skipRange to trigger updates

### DIFF
--- a/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/crunchy-bridge-operator.clusterserviceversion.yaml
@@ -83,6 +83,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    olm.skipRange: '>=0.0.2 <0.0.4'
     operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: crunchy-bridge-operator.v0.0.4-dev
@@ -429,5 +430,4 @@ spec:
   provider:
     name: Crunchy Data
     url: https://www.crunchydata.com
-  replaces: crunchy-bridge-operator.v0.0.2
   version: 0.0.4-dev

--- a/config/manifests/bases/crunchy-bridge-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/crunchy-bridge-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    olm.skipRange: '>=0.0.2 <0.0.4'
   name: crunchy-bridge-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -60,5 +61,4 @@ spec:
   provider:
     name: Crunchy Data
     url: https://www.crunchydata.com
-  replaces: crunchy-bridge-operator.v0.0.2
   version: 0.0.0


### PR DESCRIPTION
as an alternative to requiring prior bundles in the catalog image.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>