### PR TITLE
DBAAS-364: update the values for instance phase according to the api restriction

### DIFF
--- a/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinstance_types.go
+++ b/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinstance_types.go
@@ -21,6 +21,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	PhaseBlank    = ""
+	PhaseUnknown  = "Unknown"
+	PhasePending  = "Pending"
+	PhaseCreating = "Creating"
+	PhaseReady    = "Ready"
+	PhaseDeleting = "Deleting"
+	PhaseFailed   = "Failed"
+	PhaseUpdating = "Updating"
+	PhaseDeleted  = "Deleted"
+	PhaseError    = "Error"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 


### PR DESCRIPTION
With the new restriction enforced for the api of instance phase in PR https://github.com/RHEcosystemAppEng/dbaas-operator/pull/133, the code for setting instance phase need to be updated accordingly. 