### PR TITLE
DBAAS-364: update Instance Phase field to use the constants from DBaaS API

### DIFF
--- a/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinstance_types.go
+++ b/apis/dbaas.redhat.com/v1alpha1/crunchybridgeinstance_types.go
@@ -21,19 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	PhaseBlank    = ""
-	PhaseUnknown  = "Unknown"
-	PhasePending  = "Pending"
-	PhaseCreating = "Creating"
-	PhaseReady    = "Ready"
-	PhaseDeleting = "Deleting"
-	PhaseFailed   = "Failed"
-	PhaseUpdating = "Updating"
-	PhaseDeleted  = "Deleted"
-	PhaseError    = "Error"
-)
-
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/bundle/manifests/dbaas.redhat.com_crunchybridgeinstances.yaml
+++ b/bundle/manifests/dbaas.redhat.com_crunchybridgeinstances.yaml
@@ -149,10 +149,23 @@ spec:
                   instance
                 type: object
               phase:
-                description: Represents the cluster provisioning phase Pending - provisioning
-                  not yet started Creating - provisioning in progress Updating - cluster
-                  updating in progress Deleting - cluster deletion in progress Deleted
-                  - cluster has been deleted Ready - cluster provisioning complete
+                default: Unknown
+                description: Represents the cluster provisioning phase Unknown - unknown
+                  cluster provisioning status Pending - provisioning not yet started
+                  Creating - provisioning in progress Updating - cluster updating
+                  in progress Deleting - cluster deletion in progress Deleted - cluster
+                  has been deleted Ready - cluster provisioning complete Error - cluster
+                  provisioning with error Failed - cluster provisioning failed
+                enum:
+                - Unknown
+                - Pending
+                - Creating
+                - Updating
+                - Deleting
+                - Deleted
+                - Ready
+                - Error
+                - Failed
                 type: string
             required:
             - instanceID

--- a/bundle/manifests/dbaas.redhat.com_crunchybridgeinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_crunchybridgeinventories.yaml
@@ -128,6 +128,7 @@ spec:
               instances:
                 description: A list of instances returned from querying the DB provider
                 items:
+                  description: Instance defines the information of a database instance
                   properties:
                     instanceID:
                       description: A provider-specific identifier for this instance

--- a/config/crd/bases/dbaas.redhat.com_crunchybridgeinstances.yaml
+++ b/config/crd/bases/dbaas.redhat.com_crunchybridgeinstances.yaml
@@ -151,10 +151,23 @@ spec:
                   instance
                 type: object
               phase:
-                description: Represents the cluster provisioning phase Pending - provisioning
-                  not yet started Creating - provisioning in progress Updating - cluster
-                  updating in progress Deleting - cluster deletion in progress Deleted
-                  - cluster has been deleted Ready - cluster provisioning complete
+                default: Unknown
+                description: Represents the cluster provisioning phase Unknown - unknown
+                  cluster provisioning status Pending - provisioning not yet started
+                  Creating - provisioning in progress Updating - cluster updating
+                  in progress Deleting - cluster deletion in progress Deleted - cluster
+                  has been deleted Ready - cluster provisioning complete Error - cluster
+                  provisioning with error Failed - cluster provisioning failed
+                enum:
+                - Unknown
+                - Pending
+                - Creating
+                - Updating
+                - Deleting
+                - Deleted
+                - Ready
+                - Error
+                - Failed
                 type: string
             required:
             - instanceID

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/CrunchyData/crunchy-bridge-operator
 go 1.16
 
 require (
-	github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220825183828-b5d7b8e52699
+	github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220829191729-018de64ac56f
 	github.com/go-logr/logr v1.2.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
+	go.uber.org/zap v1.19.1
 	k8s.io/api v0.23.5
 	k8s.io/apiextensions-apiserver v0.23.5
 	k8s.io/apimachinery v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220825183828-b5d7b8e52699 h1:/IgYqEl245B5hLBrJcxE90Fkuzol+/wVkij88uiNrJc=
-github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220825183828-b5d7b8e52699/go.mod h1:5yvviv5SMNVM9Ns9Y3xMaBrzb7EgMfq5uROehQ+R7/Y=
+github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220829191729-018de64ac56f h1:+WPUdf/Q2JjhgcsZYvkutn9gRqV6B/AW5MShjNOyQE4=
+github.com/RHEcosystemAppEng/dbaas-operator v1.0.1-0.20220829191729-018de64ac56f/go.mod h1:5yvviv5SMNVM9Ns9Y3xMaBrzb7EgMfq5uROehQ+R7/Y=
 github.com/RHsyseng/operator-utils v1.4.9/go.mod h1:LjFIMqr7OOliHrRz1sqqFvHbdqsNlxZkSbK1cfOWinQ=
 github.com/SAP/go-hdb v0.14.1/go.mod h1:7fdQLVC2lER3urZLjZCm0AuMQfApof92n3aylBPEkMo=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -85,6 +87,7 @@ func main() {
 
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Update `Phase` field in the status of DBaaSInstance object with the values defined in the DBaaS API.
Follow-up to https://github.com/CrunchyData/crunchy-bridge-operator/pull/54